### PR TITLE
Use topological ordering in Flow execution

### DIFF
--- a/src/flow/lua_bindings.rs
+++ b/src/flow/lua_bindings.rs
@@ -80,7 +80,7 @@ impl UserData for Flow {
 
         // Sequential execution
         methods.add_method_mut("execute", |_, this, ()| {
-            let success = this.execute();
+            let success = this.execute().map_err(mlua::Error::external)?;
             Ok(success)
         });
 


### PR DESCRIPTION
## Summary
- execute workflow tasks in topological order using `petgraph::algo::toposort`
- propagate DAG cycle errors and expose through Lua bindings

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b714b6f698832b8d10de64a61ebc59