### PR TITLE
Load CLI paths from config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,6 +511,7 @@ dependencies = [
  "clap",
  "hex",
  "mlua",
+ "once_cell",
  "petgraph",
  "regex",
  "reqwest",
@@ -520,6 +521,7 @@ dependencies = [
  "serde_json",
  "sugar_path",
  "tokio",
+ "toml",
  "which",
  "wslpath-rs",
 ]
@@ -1534,6 +1536,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1795,6 +1806,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -2254,6 +2306,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winsafe"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,5 @@ sugar_path = "1.2.0"
 tokio = { version = "1.44.2", features = ["fs", "macros", "process", "rt", "rt-multi-thread", "sync", "time"] }
 which = "7.0.3"
 wslpath-rs = "0.2.0"
+once_cell = "1.19.0"
+toml = "0.8"

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,3 @@
+[cli_paths]
+dnsrecon = "dnsrecon"
+wsl = "wsl"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,24 @@
+use once_cell::sync::Lazy;
+use serde::Deserialize;
+use std::fs;
+use std::path::Path;
+
+#[derive(Debug, Deserialize)]
+pub struct CliPaths {
+    pub dnsrecon: String,
+    pub wsl: String,
+    // Otros comandos CLI pueden añadirse aquí en el futuro
+}
+
+#[derive(Debug, Deserialize)]
+struct ConfigFile {
+    pub cli_paths: CliPaths,
+}
+
+pub static CLI_PATHS: Lazy<CliPaths> = Lazy::new(|| {
+    let base_path = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let config_path = base_path.join("config.toml");
+    let contents = fs::read_to_string(config_path).expect("Failed to read config.toml");
+    let config: ConfigFile = toml::from_str(&contents).expect("Failed to parse config.toml");
+    config.cli_paths
+});

--- a/src/flow/tasks/dns_lookup_task.rs
+++ b/src/flow/tasks/dns_lookup_task.rs
@@ -6,6 +6,7 @@ use std::env::temp_dir;
 use std::path::PathBuf;
 use wslpath_rs::{windows_to_wsl, wsl_to_windows};
 
+use crate::config::CLI_PATHS;
 use tokio::process::Command;
 
 define_task!(DnsLookup, DnsLookupTask, domain: String, args: Option<Vec<String>>, replace_args: Option<bool>);
@@ -44,10 +45,14 @@ impl DnsLookupTask {
         let mut command;
 
         if cfg!(target_os = "windows") {
-            command = Command::new("wsl");
-            command.args(["--distribution", "kali-linux", "--", "dnsrecon"]);
+            command = Command::new(&CLI_PATHS.wsl);
+            command
+                .arg("--distribution")
+                .arg("kali-linux")
+                .arg("--")
+                .arg(&CLI_PATHS.dnsrecon);
         } else {
-            command = Command::new("dnsrecon");
+            command = Command::new(&CLI_PATHS.dnsrecon);
         }
 
         if let Some(args) = self.args.clone() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod config;
 mod flow;
 
 use std::env;


### PR DESCRIPTION
## Summary
- add `CliPaths` config module to load command paths from `config.toml`
- replace hardcoded dnsrecon and wsl commands with configurable paths in `DnsLookupTask`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b714bc1238832bbd2e8324c0a777a4