### PR TITLE
Add Clap CLI with init command and usage docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -212,6 +213,18 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -531,6 +544,12 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.97"
 chrono = "0.4.40"
-clap = "4.5.35"
+clap = { version = "4.5.35", features = ["derive"] }
 hex = "0.4.3"
 mlua = { version = "0.10.3", features = ["anyhow", "lua54", "vendored"] }
 petgraph = "0.6.4"

--- a/README.md
+++ b/README.md
@@ -10,3 +10,26 @@ paralelo utilizando un grafo acíclico dirigido.
 - Paso de datos entre tareas: la salida de una tarea puede modificar el
   comportamiento de la siguiente. Por ejemplo, `RunCommandTask` ahora añade
   argumentos basados en resultados de tareas previas como `DnsLookupTask`.
+
+## Uso
+
+```bash
+$ hackflow --help
+```
+
+### Inicializar un nuevo entorno
+
+```bash
+$ hackflow init
+```
+
+Esto crea una carpeta `flows` y un archivo `config.toml` con opciones
+configurables.
+
+### Ejecutar un flujo
+
+```bash
+$ hackflow run ruta/al_flujo.lua arg1 arg2
+```
+
+Los argumentos posteriores al archivo se pasan al flujo de trabajo.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,68 @@
 mod config;
 mod flow;
 
-use std::env;
+use clap::{Parser, Subcommand};
+use std::fs;
 use std::path::PathBuf;
 
-fn main() -> anyhow::Result<()> {
-    let args: Vec<String> = env::args().collect();
-    let file_path = if args.len() > 1 {
-        PathBuf::from(&args[1])
-    } else {
-        PathBuf::from("./examples/osint_workflow.lua")
-    };
+/// CLI entry point for Hackflow
+#[derive(Parser)]
+#[command(author, version, about = "Motor de orquestación de flujos", long_about = None)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
 
-    flow::Workflow::new(file_path)?.execute(args)?;
+/// Available CLI commands
+#[derive(Subcommand)]
+enum Commands {
+    /// Ejecuta un flujo definido en un archivo Lua
+    Run {
+        /// Ruta al archivo del flujo
+        file: PathBuf,
+        /// Argumentos adicionales a pasar al flujo
+        #[arg(trailing_var_arg = true)]
+        args: Vec<String>,
+    },
+    /// Crea la estructura básica de trabajo y un archivo de configuración
+    Init {
+        /// Directorio donde inicializar la estructura (por defecto el actual)
+        #[arg(default_value = ".")]
+        path: PathBuf,
+    },
+}
+
+fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Run { file, args } => run_workflow(file, args)?,
+        Commands::Init { path } => init_workspace(path)?,
+    }
 
     Ok(())
 }
+
+fn run_workflow(file: PathBuf, args: Vec<String>) -> anyhow::Result<()> {
+    let mut wf_args = vec![std::env::args().next().unwrap_or_else(|| "hackflow".into())];
+    wf_args.push(file.to_string_lossy().into_owned());
+    wf_args.extend(args);
+
+    flow::Workflow::new(file)?.execute(wf_args)?;
+    Ok(())
+}
+
+fn init_workspace(path: PathBuf) -> anyhow::Result<()> {
+    let flows_dir = path.join("flows");
+    fs::create_dir_all(&flows_dir)?;
+
+    let config_path = path.join("config.toml");
+    if !config_path.exists() {
+        fs::write(&config_path, DEFAULT_CONFIG)?;
+    }
+
+    println!("Inicializado Hackflow en {}", path.display());
+    Ok(())
+}
+
+const DEFAULT_CONFIG: &str = "[cli_paths]\ndnsrecon = \"dnsrecon\"\nwsl = \"wsl\"\n";


### PR DESCRIPTION
## Summary
- replace raw arg parsing with Clap-based CLI
- add `init` command to scaffold flows directory and default config
- document new commands in README

## Testing
- `cargo test`
- `cargo run -- --help`


------
https://chatgpt.com/codex/tasks/task_e_68b71a294c74832baf9190369c8929a7